### PR TITLE
Small typo (boder-box)

### DIFF
--- a/src/assets/app.less
+++ b/src/assets/app.less
@@ -17,8 +17,8 @@ img{
 	min-width: 22px;
 	line-height: 17px;
 	box-sizing: border-box;
-	-moz-box-sizing: boder-box;
-	-webkit-box-sizing: boder-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
 	padding: 0 4px;
 	text-align: center;
 	line-height: 22px;


### PR DESCRIPTION
Corrected the box sizing rules: border-box instead of boder-box.